### PR TITLE
feat: add option to skip validating certificate chain

### DIFF
--- a/lib/ex_pix_brcode/jws.ex
+++ b/lib/ex_pix_brcode/jws.ex
@@ -5,6 +5,6 @@ defmodule ExPixBRCode.JWS do
 
   alias ExPixBRCode.JWS.JWKSStorage
 
-  defdelegate process_keys(keys, jku), to: JWKSStorage
+  defdelegate process_keys(keys, jku, opts \\ []), to: JWKSStorage
   defdelegate jwks_storage_by_jws_headers(headers), to: JWKSStorage
 end


### PR DESCRIPTION
On this initial phase of BACEN QRCode adoption we will need to skip certificate chain validation.