### PR TITLE
refactor: Accept free text on reference_label field

### DIFF
--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -116,6 +116,7 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
     model
     |> cast(params, [:reference_label])
     |> validate_required([:reference_label])
+    |> validate_length([:reference_label], min: 1, max: 25)
   end
 
   defp validate_per_type(%{valid?: false} = c), do: c

--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -116,7 +116,7 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
     model
     |> cast(params, [:reference_label])
     |> validate_required([:reference_label])
-    |> validate_length([:reference_label], min: 1, max: 25)
+    |> validate_length(:reference_label, min: 1, max: 25)
   end
 
   defp validate_per_type(%{valid?: false} = c), do: c

--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -116,7 +116,6 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
     model
     |> cast(params, [:reference_label])
     |> validate_required([:reference_label])
-    |> validate_format(:reference_label, ~r/(^[a-zA-Z0-9]{1,25}$)|(^\*\*\*$)/)
   end
 
   defp validate_per_type(%{valid?: false} = c), do: c

--- a/test/ex_pix_brcode/decoder_test.exs
+++ b/test/ex_pix_brcode/decoder_test.exs
@@ -244,5 +244,33 @@ defmodule ExPixBRCode.DecoderTest do
                   type: :dynamic_payment_immediate
                 }}
     end
+
+    test "succeeds with BRCode has free text on reference_label field" do
+      assert Decoder.decode_to(
+               "00020126490014BR.GOV.BCB.PIX0111129989307430212Vacina covid52040000530398654031.55802BR5918BYANCA Q M PEREIRA6009SAO.PAULO62210517Lojinha da paixao63044575"
+             ) ==
+               {:ok,
+                %BRCode{
+                  additional_data_field_template: %AdditionalDataField{
+                    reference_label: "Lojinha da paixao"
+                  },
+                  country_code: "BR",
+                  crc: "4575",
+                  merchant_account_information: %MerchantAccountInfo{
+                    chave: "12998930743",
+                    gui: "BR.GOV.BCB.PIX",
+                    info_adicional: nil,
+                    url: nil
+                  },
+                  merchant_category_code: "0000",
+                  merchant_city: "SAO.PAULO",
+                  merchant_name: "BYANCA Q M PEREIRA",
+                  payload_format_indicator: "01",
+                  point_of_initiation_method: nil,
+                  transaction_amount: "1.5",
+                  transaction_currency: "986",
+                  type: :static
+                }}
+    end
   end
 end

--- a/test/ex_pix_brcode/decoder_test.exs
+++ b/test/ex_pix_brcode/decoder_test.exs
@@ -247,7 +247,7 @@ defmodule ExPixBRCode.DecoderTest do
 
     test "succeeds with BRCode has free text on reference_label field" do
       assert Decoder.decode_to(
-               "00020126490014BR.GOV.BCB.PIX0111129989307430212Vacina covid52040000530398654031.55802BR5918BYANCA Q M PEREIRA6009SAO.PAULO62210517Lojinha da paixao63044575"
+               "00020126490014BR.GOV.BCB.PIX0111111111111110212Vacina covid52040000530398654031.55802BR5904CARL6010SAN.FIERRO62210517Lojinha da paixao6304D296"
              ) ==
                {:ok,
                 %BRCode{
@@ -255,16 +255,16 @@ defmodule ExPixBRCode.DecoderTest do
                     reference_label: "Lojinha da paixao"
                   },
                   country_code: "BR",
-                  crc: "4575",
+                  crc: "D296",
                   merchant_account_information: %MerchantAccountInfo{
-                    chave: "12998930743",
+                    chave: "11111111111",
                     gui: "BR.GOV.BCB.PIX",
                     info_adicional: nil,
                     url: nil
                   },
                   merchant_category_code: "0000",
-                  merchant_city: "SAO.PAULO",
-                  merchant_name: "BYANCA Q M PEREIRA",
+                  merchant_city: "SAN.FIERRO",
+                  merchant_name: "CARL",
                   payload_format_indicator: "01",
                   point_of_initiation_method: nil,
                   transaction_amount: "1.5",


### PR DESCRIPTION
Remove `validate_format` function under reference_label field in order to accept a greater range of BRCode types