### PR TITLE
fix: 'devedor' validation

### DIFF
--- a/lib/ex_pix_brcode/payments/models/dynamic_immediate_pix_payment.ex
+++ b/lib/ex_pix_brcode/payments/models/dynamic_immediate_pix_payment.ex
@@ -100,13 +100,14 @@ defmodule ExPixBRCode.Payments.Models.DynamicImmediatePixPayment do
   defp validate_either_cpf_or_cnpj(changeset) do
     cpf = get_field(changeset, :cpf)
     cnpj = get_field(changeset, :cnpj)
+    name = get_field(changeset, :nome)
 
     cond do
-      is_nil(cpf) and is_nil(cnpj) ->
-        add_error(changeset, :devedor, "cpf or cnpj must be present")
-
       not is_nil(cpf) and not is_nil(cnpj) ->
-        add_error(changeset, :devedor, "Only one of cpf or cnpj must be present")
+        add_error(changeset, :devedor, "only one of cpf or cnpj must be present")
+
+      (not is_nil(cpf) or not is_nil(cnpj)) and is_nil(name) ->
+        add_error(changeset, :devedor, "when either cpf or cnpj is present so must be 'nome'")
 
       not is_nil(cpf) ->
         Changesets.validate_document(changeset, :cpf)

--- a/test/ex_pix_brcode/payments/models/dynamic_pix_payment_immediate_test.exs
+++ b/test/ex_pix_brcode/payments/models/dynamic_pix_payment_immediate_test.exs
@@ -5,6 +5,27 @@ defmodule ExPixBRCode.Payments.Models.DynamicImmediatePixPaymentTest do
   alias ExPixBRCode.Payments.Models.DynamicImmediatePixPayment
 
   describe "changeset/2" do
+    test "only validate 'devedor.nome' if cpf or cnpj is present" do
+      payload = %{
+        "calendario" => %{
+          "apresentacao" => "2020-11-25T18:06:39Z",
+          "criacao" => "2020-11-13T13:46:43Z",
+          "expiracao" => 3600
+        },
+        "chave" => "9463d2b0-2b1a-4157-80fe-344ccf0f7e13",
+        "devedor" => %{"cpf" => nil, "cnpj" => nil, "nome" => nil},
+        "infoAdicionais" => [%{"nome" => "Campo", "valor" => "Valor"}],
+        "revisao" => 0,
+        "solicitacaoPagador" => "Solicitação",
+        "status" => "ATIVA",
+        "txid" => "123456789012345678901234567890",
+        "valor" => %{"original" => "1.30"}
+      }
+
+      assert {:ok, %DynamicImmediatePixPayment{}} =
+               Changesets.cast_and_apply(DynamicImmediatePixPayment, payload)
+    end
+
     test "successfully validates a proper payload" do
       payload = %{
         "calendario" => %{


### PR DESCRIPTION
Only when there is either cpf or cnpj that name is mandatory. In that case, there are participants
that are using this object with all keys 'null'.