### PR TITLE
refactor: Change regex to accept all possible formats on transaction_amount

### DIFF
--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -116,6 +116,7 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
     model
     |> cast(params, [:reference_label])
     |> validate_required([:reference_label])
+    |> validate_length([:reference_label], min: 1, max: 25)
   end
 
   defp validate_per_type(%{valid?: false} = c), do: c

--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -116,7 +116,7 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
     model
     |> cast(params, [:reference_label])
     |> validate_required([:reference_label])
-    |> validate_length([:reference_label], min: 1, max: 25)
+    |> validate_length(:reference_label, min: 1, max: 25)
   end
 
   defp validate_per_type(%{valid?: false} = c), do: c

--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -116,7 +116,6 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
     model
     |> cast(params, [:reference_label])
     |> validate_required([:reference_label])
-    |> validate_format(:reference_label, ~r/(^[a-zA-Z0-9]{1,25}$)|(^\*\*\*$)/)
   end
 
   defp validate_per_type(%{valid?: false} = c), do: c

--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -77,8 +77,8 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
     |> validate_format(:merchant_category_code, ~r/^[0-9]{4}$/)
     |> validate_inclusion(:transaction_currency, ~w(986))
     |> validate_length(:transaction_amount, max: 13)
-    # Only "0" has special meaning. All other values must contain at least ONE "."
-    |> validate_format(:transaction_amount, ~r/(^0$)|(^[0-9]+\.[0-9]*$)/)
+    # Formats accept: "0", "0.10", ".10", "1.", "1", "123.99", "123456789.23"
+    |> validate_format(:transaction_amount, ~r/(^0$)|(^[0-9]+\.[0-9]{2}$)|(^[1-9]{1}([0-9])*(\.)?$)|(^\.[0-9]{2}$)/)
     |> validate_inclusion(:country_code, ~w(BR))
     |> validate_length(:postal_code, is: 8)
     |> put_type()

--- a/test/ex_pix_brcode/decoder_test.exs
+++ b/test/ex_pix_brcode/decoder_test.exs
@@ -247,7 +247,7 @@ defmodule ExPixBRCode.DecoderTest do
 
     test "succeeds with BRCode has free text on reference_label field" do
       assert Decoder.decode_to(
-               "00020126490014BR.GOV.BCB.PIX0111111111111110212Vacina covid52040000530398654031.55802BR5904CARL6010SAN.FIERRO62210517Lojinha da paixao6304D296"
+               "00020126490014BR.GOV.BCB.PIX0111111111111110212Vacina covid52040000530398654031005802BR5904CARL6010SAN.FIERRO62210517Lojinha da paixao63045982"
              ) ==
                {:ok,
                 %BRCode{
@@ -255,7 +255,7 @@ defmodule ExPixBRCode.DecoderTest do
                     reference_label: "Lojinha da paixao"
                   },
                   country_code: "BR",
-                  crc: "D296",
+                  crc: "5982",
                   merchant_account_information: %MerchantAccountInfo{
                     chave: "11111111111",
                     gui: "BR.GOV.BCB.PIX",
@@ -267,10 +267,68 @@ defmodule ExPixBRCode.DecoderTest do
                   merchant_name: "CARL",
                   payload_format_indicator: "01",
                   point_of_initiation_method: nil,
-                  transaction_amount: "1.5",
+                  transaction_amount: "100",
                   transaction_currency: "986",
                   type: :static
                 }}
     end
+
+    test "succeds with BRCode has transaction_amount with '10'" do
+      assert Decoder.decode_to(
+               "00020126490014BR.GOV.BCB.PIX0111111111111110212Vacina covid5204000053039865402105802BR5904CARL6010SAN.FIERRO62210517Lojinha da paixao63043525"
+             ) ==
+               {:ok,
+                %BRCode{
+                  additional_data_field_template: %AdditionalDataField{
+                    reference_label: "Lojinha da paixao"
+                  },
+                  country_code: "BR",
+                  crc: "3525",
+                  merchant_account_information: %MerchantAccountInfo{
+                    chave: "11111111111",
+                    gui: "BR.GOV.BCB.PIX",
+                    info_adicional: nil,
+                    url: nil
+                  },
+                  merchant_category_code: "0000",
+                  merchant_city: "SAN.FIERRO",
+                  merchant_name: "CARL",
+                  payload_format_indicator: "01",
+                  point_of_initiation_method: nil,
+                  transaction_amount: "10",
+                  transaction_currency: "986",
+                  type: :static
+                }}
+    end
+
+    test "succeds with BRCode has transaction_amount with '10.'" do
+      assert Decoder.decode_to(
+               "00020126490014BR.GOV.BCB.PIX0111111111111110212Vacina covid520400005303986540310.5802BR5904CARL6010SAN.FIERRO62210517Lojinha da paixao63040468"
+             ) ==
+               {:ok,
+                %BRCode{
+                  additional_data_field_template: %AdditionalDataField{
+                    reference_label: "Lojinha da paixao"
+                  },
+                  country_code: "BR",
+                  crc: "0468",
+                  merchant_account_information: %MerchantAccountInfo{
+                    chave: "11111111111",
+                    gui: "BR.GOV.BCB.PIX",
+                    info_adicional: nil,
+                    url: nil
+                  },
+                  merchant_category_code: "0000",
+                  merchant_city: "SAN.FIERRO",
+                  merchant_name: "CARL",
+                  payload_format_indicator: "01",
+                  point_of_initiation_method: nil,
+                  transaction_amount: "10.",
+                  transaction_currency: "986",
+                  type: :static
+                }}
+    end
+
+
   end
 end

--- a/test/ex_pix_brcode/decoder_test.exs
+++ b/test/ex_pix_brcode/decoder_test.exs
@@ -244,5 +244,33 @@ defmodule ExPixBRCode.DecoderTest do
                   type: :dynamic_payment_immediate
                 }}
     end
+
+    test "succeeds with BRCode has free text on reference_label field" do
+      assert Decoder.decode_to(
+               "00020126490014BR.GOV.BCB.PIX0111129989307430212Vacina covid52040000530398654031.55802BR5918BYANCA Q M PEREIRA6009SAO.PAULO62210517Lojinha da paixao63044575"
+             ) ==
+               {:ok,
+                %BRCode{
+                  additional_data_field_template: %AdditionalDataField{
+                    reference_label: "Lojinha da paixao"
+                  },
+                  country_code: "BR",
+                  crc: "4575",
+                  merchant_account_information: %MerchantAccountInfo{
+                    chave: "12998930743",
+                    gui: "BR.GOV.BCB.PIX",
+                    info_adicional: nil,
+                    url: nil
+                  },
+                  merchant_category_code: "0000",
+                  merchant_city: "SAO.PAULO",
+                  merchant_name: "BYANCA Q M PEREIRA",
+                  payload_format_indicator: "01",
+                  point_of_initiation_method: nil,
+                  transaction_amount: "1.5",
+                  transaction_currency: "986",
+                  type: :static
+                }}
+    end
   end
 end

--- a/test/ex_pix_brcode/decoder_test.exs
+++ b/test/ex_pix_brcode/decoder_test.exs
@@ -247,7 +247,7 @@ defmodule ExPixBRCode.DecoderTest do
 
     test "succeeds with BRCode has free text on reference_label field" do
       assert Decoder.decode_to(
-               "00020126490014BR.GOV.BCB.PIX0111129989307430212Vacina covid52040000530398654031.55802BR5918BYANCA Q M PEREIRA6009SAO.PAULO62210517Lojinha da paixao63044575"
+               "00020126490014BR.GOV.BCB.PIX0111111111111110212Vacina covid52040000530398654031.55802BR5904CARL6010SAN.FIERRO62210517Lojinha da paixao6304D296"
              ) ==
                {:ok,
                 %BRCode{
@@ -255,16 +255,16 @@ defmodule ExPixBRCode.DecoderTest do
                     reference_label: "Lojinha da paixao"
                   },
                   country_code: "BR",
-                  crc: "4575",
+                  crc: "D296",
                   merchant_account_information: %MerchantAccountInfo{
-                    chave: "12998930743",
+                    chave: "11111111111",
                     gui: "BR.GOV.BCB.PIX",
                     info_adicional: nil,
                     url: nil
                   },
                   merchant_category_code: "0000",
-                  merchant_city: "SAO.PAULO",
-                  merchant_name: "BYANCA Q M PEREIRA",
+                  merchant_city: "SAN.FIERRO",
+                  merchant_name: "CARL",
                   payload_format_indicator: "01",
                   point_of_initiation_method: nil,
                   transaction_amount: "1.5",


### PR DESCRIPTION
Based on paragraph below removed from [Bacen specification](https://www.bcb.gov.br/content/estabilidadefinanceira/pix/Regulamento_Pix/II-ManualdePadroesparaIniciacaodoPix.pdf) page 13:

![spec](https://user-images.githubusercontent.com/38814531/103846566-2b265a80-507d-11eb-9c92-d7f42f7c41f2.png)

Any field related to monetary should accept values that has the follow format: "0", "0.10", ".10", "1.", "1", "123.99", "123456789.23".
Therefore, the regex responsible to validate this format should be refactored. 