### PR TITLE
feat: add thumbprint validation with sha256

### DIFF
--- a/lib/ex_pix_brcode/jws/models/jws_headers.ex
+++ b/lib/ex_pix_brcode/jws/models/jws_headers.ex
@@ -5,24 +5,40 @@ defmodule ExPixBRCode.JWS.Models.JWSHeaders do
 
   use ExPixBRCode.ValueObject
 
-  @required [:jku, :kid, :x5t, :alg]
+  @required [:jku, :kid, :alg]
+  @optional [:x5t, :"x5t#S256"]
 
   embedded_schema do
     field :jku, :string
     field :kid, :string
     field :x5t, :string
+    field :"x5t#S256", :string
     field :alg, :string
   end
 
   @doc false
   def changeset(model \\ %__MODULE__{}, params) do
     model
-    |> cast(params, @required)
+    |> cast(params, @required ++ @optional)
     |> validate_required(@required)
+    |> validate_at_least_one_thumbprint()
     |> validate_exclusion(:alg, ~w(none HS256 HS384 HS512))
     |> validate_length(:alg, is: 5)
     |> ensure_jku_https()
     |> validate_change(:jku, &validate_jku/2)
+  end
+
+  defp validate_at_least_one_thumbprint(%{valid?: false} = c), do: c
+
+  defp validate_at_least_one_thumbprint(changeset) do
+    x5t = get_field(changeset, :x5t)
+    x5tS256 = get_field(changeset, :"x5t#S256")
+
+    if is_nil(x5t) and is_nil(x5tS256) do
+      add_error(changeset, :thumbprint, "Missing either `x5t` or `x5t#S256`")
+    else
+      changeset
+    end
   end
 
   defp ensure_jku_https(%{valid?: false} = c), do: c

--- a/lib/ex_pix_brcode/payments/dynamic_pix_loader.ex
+++ b/lib/ex_pix_brcode/payments/dynamic_pix_loader.ex
@@ -34,7 +34,8 @@ defmodule ExPixBRCode.Payments.DynamicPixLoader do
 
   defp do_process_jws(client, url, jws, opts) do
     with {:ok, header_claims} <- Joken.peek_header(jws),
-         {:ok, header_claims} <- Changesets.cast_and_apply(JWSHeaders, header_claims),
+         {:ok, header_claims} <-
+           Changesets.cast_and_apply(JWSHeaders, header_claims),
          {:ok, jwks_storage} <- fetch_jwks_storage(client, header_claims, opts),
          :ok <- verify_certificate(jwks_storage.certificate),
          :ok <- verify_alg(jwks_storage.jwk, header_claims.alg),

--- a/test/ex_pix_brcode/dynamic_pix_loader_test.exs
+++ b/test/ex_pix_brcode/dynamic_pix_loader_test.exs
@@ -50,6 +50,11 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
       |> :crypto.hash(raw_cert)
       |> Base.url_encode64(padding: false)
 
+    thumbprintS256 =
+      :sha256
+      |> :crypto.hash(raw_cert)
+      |> Base.url_encode64(padding: false)
+
     kid = Ecto.UUID.generate()
 
     pem = my_key |> JOSE.JWK.from_key() |> JOSE.JWK.to_pem()
@@ -63,6 +68,13 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
         "jku" => jku
       })
 
+    signerS256 =
+      Joken.Signer.create("RS256", %{"pem" => pem}, %{
+        "x5t#S256" => thumbprintS256,
+        "kid" => kid,
+        "jku" => jku
+      })
+
     jwks = %{
       "keys" => [
         Map.merge(
@@ -71,6 +83,7 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
             "kid" => kid,
             "x5c" => x5c,
             "x5t" => thumbprint,
+            "x5t#S256" => thumbprintS256,
             "kty" => "RSA",
             "key_ops" => ["verify"]
           }
@@ -78,7 +91,7 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
       ]
     }
 
-    {:ok, jku: jku, signer: signer, jwks: jwks}
+    {:ok, jku: jku, signer: signer, signerS256: signerS256, jwks: jwks}
   end
 
   describe "load_pix/2" do
@@ -135,6 +148,98 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
         %{url: ^pix_url} ->
           %{}
           |> Joken.generate_and_sign!(payment, ctx.signer)
+          |> Tesla.Mock.text(headers: [{"content-type", "application/jose"}])
+
+        %{url: ^jku} ->
+          key = ctx.jwks["keys"] |> hd()
+
+          key = %{key | "x5c" => Enum.reverse(key["x5c"])}
+
+          Tesla.Mock.json(%{keys: [key]})
+      end)
+
+      assert {:ok,
+              %DynamicImmediatePixPayment{
+                calendario: %Calendario{
+                  apresentacao: ~U[2020-11-28 03:15:39Z],
+                  criacao: ~U[2020-11-13 23:59:49Z],
+                  expiracao: 86400
+                },
+                chave: "14413050762",
+                devedor: nil,
+                infoAdicionais: [],
+                revisao: 0,
+                solicitacaoPagador: nil,
+                status: :ATIVA,
+                txid: "4DE46328260C11EB91C04049FC2CA371",
+                valor: %Valor{original: Decimal.new("1.00")}
+              }} ==
+               DynamicPixLoader.load_pix(@client, pix_url,
+                 leaf_certificate_should_fail: false,
+                 x5c_should_fail: false
+               )
+
+      x5t = ctx.jwks["keys"] |> hd() |> Map.get("x5t")
+      kid = ctx.jwks["keys"] |> hd() |> Map.get("kid")
+      key = {x5t, kid}
+      assert %{^key => _} = :persistent_term.get(ctx.jku)
+    end
+  end
+
+  describe "load_pix/2 - x5t#S256" do
+    for key_type <- [
+          :cpf,
+          :cnpj,
+          :phone,
+          :email,
+          :random_key
+        ] do
+      test "succeeds for payment with #{key_type} key", %{jku: jku} = ctx do
+        payment = build_pix_payment() |> with_key(unquote(key_type))
+        pix_url = "https://somepixpsp.br/pix/v2/#{Ecto.UUID.generate()}"
+
+        Tesla.Mock.mock(fn
+          %{url: ^pix_url} ->
+            %{}
+            |> Joken.generate_and_sign!(payment, ctx.signerS256)
+            |> Tesla.Mock.text(headers: [{"content-type", "application/jose"}])
+
+          %{url: ^jku} ->
+            Tesla.Mock.json(ctx.jwks)
+        end)
+
+        assert {:ok,
+                %DynamicImmediatePixPayment{
+                  calendario: %Calendario{
+                    apresentacao: ~U[2020-11-28 03:15:39Z],
+                    criacao: ~U[2020-11-13 23:59:49Z],
+                    expiracao: 86400
+                  },
+                  chave: payment.chave,
+                  devedor: nil,
+                  infoAdicionais: [],
+                  revisao: 0,
+                  solicitacaoPagador: nil,
+                  status: :ATIVA,
+                  txid: "4DE46328260C11EB91C04049FC2CA371",
+                  valor: %Valor{original: Decimal.new("1.00")}
+                }} == DynamicPixLoader.load_pix(@client, pix_url)
+
+        x5t = ctx.jwks["keys"] |> hd() |> Map.get("x5t")
+        kid = ctx.jwks["keys"] |> hd() |> Map.get("kid")
+        key = {x5t, kid}
+        assert %{^key => _} = :persistent_term.get(ctx.jku)
+      end
+    end
+
+    test "can skip certifica validations", %{jku: jku} = ctx do
+      payment = build_pix_payment()
+      pix_url = "https://somepixpsp.br/pix/v2/#{Ecto.UUID.generate()}"
+
+      Tesla.Mock.mock(fn
+        %{url: ^pix_url} ->
+          %{}
+          |> Joken.generate_and_sign!(payment, ctx.signerS256)
           |> Tesla.Mock.text(headers: [{"content-type", "application/jose"}])
 
         %{url: ^jku} ->


### PR DESCRIPTION
Key thumbprint might use sha1 or sha256. As per the specification we need to ensure that sha256 is also accounted. Some JWKSs have only the sha256 thumbprint (although the spec is not clear if that is correct if I remember correctly).

I have added validations for casting and matching a key in the persistent_term.