### PR TITLE
fix: request params to load due date pix payment

### DIFF
--- a/lib/ex_pix_brcode/payments/dynamic_pix_loader.ex
+++ b/lib/ex_pix_brcode/payments/dynamic_pix_loader.ex
@@ -17,8 +17,12 @@ defmodule ExPixBRCode.Payments.DynamicPixLoader do
 
   @doc """
   Given a `t:Tesla.Client` and a PIX payment URL it loads its details after validation.
+
+  ## Options
+    * `:dpp` - The intended payment date.
+    * `:cod_mun` - The customer municipality code.
   """
-  @spec load_pix(Tesla.Client.t(), String.t()) ::
+  @spec load_pix(Tesla.Client.t(), String.t(), keyword()) ::
           {:ok, DynamicImmediatePixPayment.t() | DynamicPixPaymentWithDueDate.t()}
           | {:error, atom()}
   def load_pix(client, url, opts \\ []) do
@@ -145,8 +149,7 @@ defmodule ExPixBRCode.Payments.DynamicPixLoader do
     |> Enum.filter(fn {opt, value} -> opt in @valid_query_params and not is_nil(value) end)
     |> Enum.map(fn
       {:cod_mun, value} -> {:codMun, value}
-      {:dpp, value} -> {:DDP, value}
-      opt -> opt
+      {:dpp, value} -> {:DPP, value}
     end)
   end
 end

--- a/test/ex_pix_brcode/payments/models/dynamic_pix_payment_with_due_date_test.exs
+++ b/test/ex_pix_brcode/payments/models/dynamic_pix_payment_with_due_date_test.exs
@@ -19,7 +19,7 @@ defmodule ExPixBRCode.Payments.Models.DynamicPixPaymentWithDueDateTest do
         },
         "devedor" => %{
           "cpf" => Brcpfcnpj.cpf_generate(),
-          "nome" => "Ciclano"
+          "nome" => "Cicrano"
         },
         "valor" => %{"original" => "1.30", "final" => "1.30"},
         "recebedor" => %{
@@ -51,7 +51,7 @@ defmodule ExPixBRCode.Payments.Models.DynamicPixPaymentWithDueDateTest do
         },
         "devedor" => %{
           "cpf" => Brcpfcnpj.cpf_generate(),
-          "nome" => "Ciclano"
+          "nome" => "Cicrano"
         },
         "valor" => %{
           "original" => "7.30",
@@ -96,7 +96,7 @@ defmodule ExPixBRCode.Payments.Models.DynamicPixPaymentWithDueDateTest do
         },
         "devedor" => %{
           "cpf" => Brcpfcnpj.cpf_generate(),
-          "nome" => "Ciclano"
+          "nome" => "Cicrano"
         },
         "valor" => %{"original" => "1.30", "final" => "1.30"},
         "recebedor" => %{
@@ -110,6 +110,37 @@ defmodule ExPixBRCode.Payments.Models.DynamicPixPaymentWithDueDateTest do
       }
 
       assert {:ok, %DynamicPixPaymentWithDueDate{}} =
+               Changesets.cast_and_apply(DynamicPixPaymentWithDueDate, payload)
+    end
+
+    test "successfully validates an invalid payload with zero values on valor attribute" do
+      payload = %{
+        "revisao" => 0,
+        "chave" => "9463d2b0-2b1a-4157-80fe-344ccf0f7e13",
+        "status" => "ATIVA",
+        "txid" => "1234",
+        "solicitacaoPagador" => "Solicitação",
+        "calendario" => %{
+          "criacao" => "2021-02-24 22:10:58.154290Z",
+          "apresentacao" => "2021-02-24 22:23:49.246328Z",
+          "dataDeVencimento" => "2021-02-28 22:23:49.246328Z"
+        },
+        "devedor" => %{
+          "cpf" => Brcpfcnpj.cpf_generate(),
+          "nome" => "Cicrano"
+        },
+        "valor" => %{"original" => "1.30", "final" => "1.30", "desconto" => "0.00"},
+        "recebedor" => %{
+          "cpf" => Brcpfcnpj.cpf_generate(),
+          "nome" => "Fulano",
+          "cidade" => "Rio de Janeiro",
+          "uf" => "RJ",
+          "cep" => "28610-160",
+          "logradouro" => "Avenida Brasil"
+        }
+      }
+
+      assert {:error, {:validation, _}} =
                Changesets.cast_and_apply(DynamicPixPaymentWithDueDate, payload)
     end
   end


### PR DESCRIPTION
## Changes

Fix typo in query parameter during load dynamic due date pix payment. The library was requesting other PSPs with `DDP` query parameter instead of `DPP`.