### PR TITLE
feat: add pss to brcode

### DIFF
--- a/lib/ex_pix_brcode/brcode/decoder.ex
+++ b/lib/ex_pix_brcode/brcode/decoder.ex
@@ -15,6 +15,7 @@ defmodule ExPixBRCode.BRCodes.Decoder do
          "00" => "gui",
          "01" => "chave",
          "02" => "info_adicional",
+         "03" => "pss",
          "25" => "url"
        }},
     "52" => "merchant_category_code",

--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -35,6 +35,7 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
       # Static fields
       field :chave, :string
       field :info_adicional, :string
+      field :pss, :string
 
       # Dynamic fields
       field :url, :string
@@ -115,12 +116,13 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
 
   defp validate_merchant_acc_info(model, params) do
     model
-    |> cast(params, [:gui, :chave, :url, :info_adicional])
+    |> cast(params, [:gui, :chave, :url, :info_adicional, :pss])
     |> validate_required([:gui])
     |> validate_inclusion(:gui, ["br.gov.bcb.pix", "BR.GOV.BCB.PIX"])
     |> validate_length(:chave, min: 1, max: 77)
     |> validate_length(:info_adicional, min: 1, max: 72)
     |> validate_length(:url, min: 1, max: 77)
+    |> validate_length(:pss, is: 8)
     |> validate_per_type()
   end
 

--- a/lib/ex_pix_brcode/payments.ex
+++ b/lib/ex_pix_brcode/payments.ex
@@ -41,7 +41,8 @@ defmodule ExPixBRCode.Payments do
         key_type: key_type,
         additional_information: brcode.merchant_account_information.info_adicional,
         transaction_amount: brcode.transaction_amount,
-        transaction_id: brcode.additional_data_field_template.reference_label
+        transaction_id: brcode.additional_data_field_template.reference_label,
+        withdrawal_service_provider: brcode.merchant_account_information.pss
       })
     end
   end

--- a/lib/ex_pix_brcode/payments/models/static_pix_payment.ex
+++ b/lib/ex_pix_brcode/payments/models/static_pix_payment.ex
@@ -10,7 +10,13 @@ defmodule ExPixBRCode.Payments.Models.StaticPixPayment do
   use ExPixBRCode.ValueObject
 
   @required [:key]
-  @optional [:transaction_amount, :transaction_id, :additional_information, :key_type]
+  @optional [
+    :transaction_amount,
+    :transaction_id,
+    :additional_information,
+    :key_type,
+    :withdrawal_service_provider
+  ]
   @transaction_amount_format ~r/^[0-9]+\.[0-9]{2}$|^[0-9]+\.[0-9]{1}$|^[1-9]{1}[0-9]*\.?$|^\.[0-9]{2}$/
 
   embedded_schema do
@@ -19,6 +25,7 @@ defmodule ExPixBRCode.Payments.Models.StaticPixPayment do
     field :additional_information, :string
     field :transaction_amount, :string
     field :transaction_id, :string
+    field :withdrawal_service_provider, :string
   end
 
   @doc false
@@ -28,6 +35,7 @@ defmodule ExPixBRCode.Payments.Models.StaticPixPayment do
     |> validate_required(@required)
     |> validate_format(:transaction_amount, @transaction_amount_format)
     |> validate_format(:transaction_id, ~r(^[a-zA-Z0-9]{1,25}$|^\*\*\*$))
+    |> validate_length(:withdrawal_service_provider, is: 8)
     |> validate_random_key_format()
   end
 

--- a/lib/ex_pix_brcode/payments/models/static_pix_payment.ex
+++ b/lib/ex_pix_brcode/payments/models/static_pix_payment.ex
@@ -36,6 +36,7 @@ defmodule ExPixBRCode.Payments.Models.StaticPixPayment do
     |> validate_format(:transaction_amount, @transaction_amount_format)
     |> validate_format(:transaction_id, ~r(^[a-zA-Z0-9]{1,25}$|^\*\*\*$))
     |> validate_length(:withdrawal_service_provider, is: 8)
+    |> validate_format(:withdrawal_service_provider, ~r/^[[:digit:]]+$/)
     |> validate_random_key_format()
   end
 

--- a/test/ex_pix_brcode/payments/models/static_pix_payment_test.exs
+++ b/test/ex_pix_brcode/payments/models/static_pix_payment_test.exs
@@ -5,6 +5,17 @@ defmodule ExPixBRCode.Payments.Models.StaticPixPaymentTest do
   alias ExPixBRCode.Payments.Models.StaticPixPayment
 
   describe "changeset/2" do
+    test "successfully validates static pix payment" do
+      payload = %{
+        "key" => "9463a2a0-2b1a-4157-80fe-344ccf0f7e13",
+        "key_type" => "random_key",
+        "transaction_id" => "000112aa",
+        "transaction_amount" => "10.36"
+      }
+
+      assert {:ok, %StaticPixPayment{}} = Changesets.cast_and_apply(StaticPixPayment, payload)
+    end
+
     test "successfully on validates a proper UUID random key" do
       payload = %{
         "key" => "9463A2A0-2b1A-4157-80fe-344ccf0f7e13",
@@ -17,6 +28,37 @@ defmodule ExPixBRCode.Payments.Models.StaticPixPaymentTest do
                Changesets.cast_and_apply(StaticPixPayment, payload)
 
       assert [key: {"has invalid format", []}] == changeset.errors
+    end
+
+    test "successfully validates static pix payment with withdrawal service provider" do
+      payload = %{
+        "key" => "9463a2a0-2b1a-4157-80fe-344ccf0f7e13",
+        "key_type" => "random_key",
+        "transaction_id" => "000112aa",
+        "transaction_amount" => "10.36",
+        "withdrawal_service_provider" => "16501555"
+      }
+
+      assert {:ok, %StaticPixPayment{}} = Changesets.cast_and_apply(StaticPixPayment, payload)
+    end
+
+    test "successfully on validates a proper withdrawal service provider" do
+      payload = %{
+        "key" => "9463a2a0-2b1a-4157-80fe-344ccf0f7e13",
+        "key_type" => "random_key",
+        "transaction_id" => "000112aa",
+        "transaction_amount" => "10.36",
+        "withdrawal_service_provider" => "16501"
+      }
+
+      assert {:error, {:validation, changeset}} =
+               Changesets.cast_and_apply(StaticPixPayment, payload)
+
+      assert [
+               withdrawal_service_provider:
+                 {"should be %{count} character(s)",
+                  [{:count, 8}, {:validation, :length}, {:kind, :is}, {:type, :string}]}
+             ] == changeset.errors
     end
   end
 end

--- a/test/ex_pix_brcode/payments_test.exs
+++ b/test/ex_pix_brcode/payments_test.exs
@@ -21,6 +21,7 @@ defmodule ExPixBRCode.PaymentTest do
                  chave: "123e4567-e12b-12d1-a456-426655440000",
                  gui: "br.gov.bcb.pix",
                  info_adicional: nil,
+                 pss: nil,
                  url: nil
                },
                merchant_category_code: "0000",
@@ -40,14 +41,15 @@ defmodule ExPixBRCode.PaymentTest do
                 key: "123e4567-e12b-12d1-a456-426655440000",
                 key_type: "random_key",
                 transaction_amount: nil,
-                transaction_id: "***"
+                transaction_id: "***",
+                withdrawal_service_provider: nil
               }} == Payments.from_brcode(nil, brcode)
     end
 
     test "successfully cast static payment with optional fields" do
       assert {:ok, brcode} =
                Decoder.decode_to(
-                 "00020126490014BR.GOV.BCB.PIX0111111111111110212Vacina covid52040000530398654031005802BR5904CARL6010SAN.FIERRO62070503aB16304AE0E"
+                 "00020126610014BR.GOV.BCB.PIX0111111111111110212Vacina covid03081650155552040000530398654031005802BR5904CARL6010SAN.FIERRO62070503aB16304327E"
                )
 
       assert brcode == %BRCode{
@@ -55,11 +57,12 @@ defmodule ExPixBRCode.PaymentTest do
                  reference_label: "aB1"
                },
                country_code: "BR",
-               crc: "AE0E",
+               crc: "327E",
                merchant_account_information: %BRCode.MerchantAccountInfo{
                  chave: "11111111111",
                  gui: "BR.GOV.BCB.PIX",
                  info_adicional: "Vacina covid",
+                 pss: "16501555",
                  url: nil
                },
                merchant_category_code: "0000",
@@ -79,7 +82,8 @@ defmodule ExPixBRCode.PaymentTest do
                 key: "11111111111",
                 key_type: "cpf",
                 transaction_amount: "100",
-                transaction_id: "aB1"
+                transaction_id: "aB1",
+                withdrawal_service_provider: "16501555"
               }} == Payments.from_brcode(nil, brcode)
     end
   end


### PR DESCRIPTION
This PR adds support to read static QRcodes from Pix withdrawal . The following changes will be made:

1 - Add field `pss` to Merchant Account Information (stores ISPB values)
2 - Add field `withdrawal_service_provider` to Static Pix Payment (stores ISPB values)