### PR TITLE
feat: validate parameters for RSA and EC public keys

### DIFF
--- a/lib/ex_pix_brcode/jws/models/jwks.ex
+++ b/lib/ex_pix_brcode/jws/models/jwks.ex
@@ -98,6 +98,7 @@ defmodule ExPixBRCode.JWS.Models.JWKS do
   defp validate_rsa_key(changeset, n, e), do: validate_rsa_params(changeset, n, e)
 
   defp validate_rsa_params(changeset, n, e) do
+    # https://datatracker.ietf.org/doc/html/rfc7518#section-6.3.1
     case {:n, Base.url_decode64(n, padding: false), :e, Base.url_decode64(e, padding: false)} do
       {:n, :error, :e, :error} ->
         changeset

--- a/lib/ex_pix_brcode/jws/models/jwks.ex
+++ b/lib/ex_pix_brcode/jws/models/jwks.ex
@@ -117,6 +117,7 @@ defmodule ExPixBRCode.JWS.Models.JWKS do
   end
 
   defp validate_curve_params(changeset, x, y) do
+    # https://datatracker.ietf.org/doc/html/rfc7518#section-6.2.1
     case {:x, Base.url_decode64(x, padding: false), :y, Base.url_decode64(y, padding: false)} do
       {:x, :error, :y, :error} ->
         changeset

--- a/lib/ex_pix_brcode/payments/dynamic_pix_loader.ex
+++ b/lib/ex_pix_brcode/payments/dynamic_pix_loader.ex
@@ -38,6 +38,8 @@ defmodule ExPixBRCode.Payments.DynamicPixLoader do
       {:error, _} = err ->
         err
     end
+  rescue
+    _ -> :error
   end
 
   defp do_process_jws(client, url, jws, opts) do

--- a/test/ex_pix_brcode/dynamic_pix_loader_test.exs
+++ b/test/ex_pix_brcode/dynamic_pix_loader_test.exs
@@ -7,7 +7,7 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
 
   @client Tesla.client([], Tesla.Mock)
 
-  setup_all do
+  setup do
     ca_key = X509.PrivateKey.new_rsa(1024)
 
     ca =
@@ -91,7 +91,22 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
       ]
     }
 
-    {:ok, jku: jku, signer: signer, signerS256: signerS256, jwks: jwks}
+    invalid_jwk = %{
+      "keys" => [
+        %{
+          "kid" => kid,
+          "x5c" => x5c,
+          "x5t" => thumbprint,
+          "kty" => "RSA",
+          "e" => "AQAB",
+          "n" =>
+            "0DO2yRYKsVKTbkUTyjkd6a5qLLQRhlkmzOek2ZLLX8ohaZU8NDGjLCvLCA8kPM7cS7j/7uE8g2tskBMsiIyiS8EZ6HzDbdx4A60ncvrAiGb0Y9dZETtld2W3Wf8EaveIdllLOy0379CQw9v/rvHLaJvr1/Rjp5je4LSMTiSW7nDSliNq41hwfXBoSRtst6fmejTL81Bvmn7TjYgQohwu++dRhhltlJJLEl/eAffx7JZLbDFC4WRWk1jbCbf2Q80NlEftm72gDUz79nLg2Dv6igaH3pm8X7mBrgmmxscy5Jmdn32zcvTvwZVEFa0ri7S96Ho4BZdCTuacMrPxq7sjEw",
+          "key_ops" => ["verify"]
+        }
+      ]
+    }
+
+    {:ok, jku: jku, signer: signer, signerS256: signerS256, jwks: jwks, invalid_jwk: invalid_jwk}
   end
 
   describe "load_pix/2" do
@@ -243,6 +258,25 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
       kid = ctx.jwks["keys"] |> hd() |> Map.get("kid")
       key = {x5t, kid}
       assert %{^key => _} = :persistent_term.get(ctx.jku)
+    end
+
+    @tag :focus
+    test "validates parameters for RSA public keys",
+         %{jku: jku, invalid_jwk: invalid_jwk} = ctx do
+      payment = build_pix_payment() |> with_key(:cpf)
+      pix_url = "https://somepixpsp.br/pix/v2/#{Ecto.UUID.generate()}"
+
+      Tesla.Mock.mock(fn
+        %{url: ^pix_url} ->
+          %{}
+          |> Joken.generate_and_sign!(payment, ctx.signer)
+          |> Tesla.Mock.text(headers: [{"content-type", "application/jose"}])
+
+        %{url: ^jku} ->
+          Tesla.Mock.json(invalid_jwk)
+      end)
+
+      assert {:error, {:validation, _}} = DynamicPixLoader.load_pix(@client, pix_url)
     end
   end
 

--- a/test/ex_pix_brcode/dynamic_pix_loader_test.exs
+++ b/test/ex_pix_brcode/dynamic_pix_loader_test.exs
@@ -260,7 +260,6 @@ defmodule ExPixBRCode.Payments.DynamicPixLoaderTest do
       assert %{^key => _} = :persistent_term.get(ctx.jku)
     end
 
-    @tag :focus
     test "validates parameters for RSA public keys",
          %{jku: jku, invalid_jwk: invalid_jwk} = ctx do
       payment = build_pix_payment() |> with_key(:cpf)


### PR DESCRIPTION
Add validation for `n` and `e`, parameters related with RSA, and `x` and `y`, parameters related with EC. 