### PR TITLE
fix: rename pss to fss

### DIFF
--- a/lib/ex_pix_brcode/brcode/decoder.ex
+++ b/lib/ex_pix_brcode/brcode/decoder.ex
@@ -15,7 +15,7 @@ defmodule ExPixBRCode.BRCodes.Decoder do
          "00" => "gui",
          "01" => "chave",
          "02" => "info_adicional",
-         "03" => "pss",
+         "03" => "fss",
          "25" => "url"
        }},
     "52" => "merchant_category_code",

--- a/lib/ex_pix_brcode/brcode/models/brcode.ex
+++ b/lib/ex_pix_brcode/brcode/models/brcode.ex
@@ -35,7 +35,7 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
       # Static fields
       field :chave, :string
       field :info_adicional, :string
-      field :pss, :string
+      field :fss, :string
 
       # Dynamic fields
       field :url, :string
@@ -116,13 +116,13 @@ defmodule ExPixBRCode.BRCodes.Models.BRCode do
 
   defp validate_merchant_acc_info(model, params) do
     model
-    |> cast(params, [:gui, :chave, :url, :info_adicional, :pss])
+    |> cast(params, [:gui, :chave, :url, :info_adicional, :fss])
     |> validate_required([:gui])
     |> validate_inclusion(:gui, ["br.gov.bcb.pix", "BR.GOV.BCB.PIX"])
     |> validate_length(:chave, min: 1, max: 77)
     |> validate_length(:info_adicional, min: 1, max: 72)
     |> validate_length(:url, min: 1, max: 77)
-    |> validate_length(:pss, is: 8)
+    |> validate_length(:fss, is: 8)
     |> validate_per_type()
   end
 

--- a/lib/ex_pix_brcode/payments.ex
+++ b/lib/ex_pix_brcode/payments.ex
@@ -42,7 +42,7 @@ defmodule ExPixBRCode.Payments do
         additional_information: brcode.merchant_account_information.info_adicional,
         transaction_amount: brcode.transaction_amount,
         transaction_id: brcode.additional_data_field_template.reference_label,
-        withdrawal_service_provider: brcode.merchant_account_information.pss
+        withdrawal_service_provider: brcode.merchant_account_information.fss
       })
     end
   end

--- a/test/ex_pix_brcode/payments_test.exs
+++ b/test/ex_pix_brcode/payments_test.exs
@@ -21,7 +21,7 @@ defmodule ExPixBRCode.PaymentTest do
                  chave: "123e4567-e12b-12d1-a456-426655440000",
                  gui: "br.gov.bcb.pix",
                  info_adicional: nil,
-                 pss: nil,
+                 fss: nil,
                  url: nil
                },
                merchant_category_code: "0000",
@@ -62,7 +62,7 @@ defmodule ExPixBRCode.PaymentTest do
                  chave: "11111111111",
                  gui: "BR.GOV.BCB.PIX",
                  info_adicional: "Vacina covid",
-                 pss: "16501555",
+                 fss: "16501555",
                  url: nil
                },
                merchant_category_code: "0000",


### PR DESCRIPTION
Setting `pss` field naming to `fss`.